### PR TITLE
filter out vendors with no products

### DIFF
--- a/src/app/modules/Scraper/scraper.controller.js
+++ b/src/app/modules/Scraper/scraper.controller.js
@@ -8,16 +8,23 @@ const getAllScrape = catchAsync(async (req, res) => {
     product = product.replace(/\s+/g, "%20");
     const scrapers = await ScrapperService.getAllScrape(product);
   
-  const response = scraperSources.map(({ key, name }) => ({
-    name,
-    products: scrapers[key]?.products,
-    logo: scrapers[key]?.logo,
-  }));
+   // Filter out vendors with no products
+   const filteredResponse = scraperSources.reduce((vendor, {key, name}) => {
+    const products = scrapers[key]?.products;
+    if(products && products?.length > 0){
+      vendor.push({
+        name, 
+        products,
+        logo: scrapers[key]?.logo,
+      })
+    }
+    return vendor;
+  }, [])
   sendResponse(res, {
     statusCode: 200,
     success: true,
     message: "Scraping data successfully",
-    data: response,
+    data: filteredResponse,
   });
 });
 export const ScrapperController= {


### PR DESCRIPTION
Previously, the search endpoint was returning vendors even when they had no products found, leading to an empty display in the frontend. This update filters out vendors that don't have any products, ensuring that only vendors with at least one product are included in the search results.

**Changes Made:**
- Added a check to exclude vendors with empty product lists.
- Cleaned up the filtering logic for better performance and accuracy.

Impact:
Improves user experience by preventing empty vendor cards from appearing in the search results.